### PR TITLE
Configure Vite proxy for API calls

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -17,4 +17,12 @@ export default defineConfig({
       '@': fileURLToPath(new URL('./src', import.meta.url))
     },
   },
+  server: {
+    proxy: {
+      '/api': {
+        target: 'http://localhost:3000',
+        changeOrigin: true,
+      },
+    },
+  },
 })


### PR DESCRIPTION
## Summary
- route `/api` requests through Vite dev server to the backend server on port 3000

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684ecbcb3334832cb5439167b6a705e7