### PR TITLE
Add server selector to nav bar

### DIFF
--- a/public/default-server-icon.svg
+++ b/public/default-server-icon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="64" height="64">
+  <rect width="64" height="64" rx="12" ry="12" fill="#888888"/>
+  <text x="32" y="37" font-size="28" text-anchor="middle" fill="#ffffff" font-family="Arial, Helvetica, sans-serif">S</text>
+</svg>

--- a/src/components/ServerList.vue
+++ b/src/components/ServerList.vue
@@ -26,7 +26,7 @@ function openServer(id: string) {
         @click="openServer(server.id)"
       >
         <div class="server-icon">
-          <img v-if="server.icon" :src="server.icon" alt="server icon" />
+          <img :src="server.icon || '/default-server-icon.svg'" alt="server icon" />
         </div>
         <span class="server-name">{{ server.name }}</span>
       </li>


### PR DESCRIPTION
## Summary
- show list of servers in the nav bar
- fetch servers globally and clear them on logout
- display a placeholder image when a server has no icon

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build-only`


------
https://chatgpt.com/codex/tasks/task_e_684f23c389b0832c8097cf48ac28f70c