### PR TITLE
Add queue add feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,9 @@ npm run build
 ```sh
 npm run lint
 ```
+
+## Adding Songs to the Queue
+
+While viewing a server's player page, enter a song or playlist URL in the **Add**
+ form and submit it to queue the track using the `/api/queue/{guildId}/add`
+ endpoint. Optionally provide your name to mark who requested the song.

--- a/README.md
+++ b/README.md
@@ -43,4 +43,5 @@ npm run lint
 
 While viewing a server's player page, enter a song or playlist URL in the **Add**
  form and submit it to queue the track using the `/api/queue/{guildId}/add`
- endpoint. Optionally provide your name to mark who requested the song.
+ endpoint. The requester field is automatically filled with your Discord
+ username.

--- a/src/views/PlayerView.vue
+++ b/src/views/PlayerView.vue
@@ -27,6 +27,9 @@ const guildId = route.params.guildId as string
 const currentTrack = ref<TrackMetadata | null>(null)
 const queue = ref<QueueItem[]>([])
 
+const newUrl = ref('')
+const newRequester = ref('')
+
 async function loadData() {
   try {
     const res = await axios.get(`/api/now-playing/${guildId}`)
@@ -60,6 +63,23 @@ async function stop() {
   await loadData()
 }
 
+async function addTrack() {
+  if (!newUrl.value) {
+    return
+  }
+  try {
+    await axios.post(`/api/queue/${guildId}/add`, {
+      url: newUrl.value,
+      requester: newRequester.value || undefined,
+    })
+    newUrl.value = ''
+    newRequester.value = ''
+    await loadData()
+  } catch (err) {
+    console.error(err)
+  }
+}
+
 onMounted(loadData)
 </script>
 
@@ -82,6 +102,20 @@ onMounted(loadData)
       <button @click="skip">Skip</button>
       <button @click="stop">Stop</button>
     </div>
+
+    <form class="add-form" @submit.prevent="addTrack">
+      <input
+        v-model="newUrl"
+        type="text"
+        placeholder="Song or playlist URL"
+      />
+      <input
+        v-model="newRequester"
+        type="text"
+        placeholder="Your name (optional)"
+      />
+      <button type="submit">Add</button>
+    </form>
 
     <div class="queue">
       <h4>Queue</h4>
@@ -118,6 +152,27 @@ onMounted(loadData)
   background: #2a2a2a;
   border: none;
   color: #e0e0e0;
+  cursor: pointer;
+}
+
+.add-form {
+  margin-top: 1rem;
+  display: flex;
+  gap: 0.5rem;
+}
+
+.add-form input {
+  padding: 0.5rem;
+  background: #2a2a2a;
+  border: none;
+  color: #e0e0e0;
+}
+
+.add-form button {
+  padding: 0.5rem 1rem;
+  background: #4caf50;
+  border: none;
+  color: #fff;
   cursor: pointer;
 }
 

--- a/src/views/PlayerView.vue
+++ b/src/views/PlayerView.vue
@@ -29,6 +29,7 @@ const queue = ref<QueueItem[]>([])
 
 const newUrl = ref('')
 const username = ref('')
+const userId = ref('')
 
 async function loadUsername() {
   const token = localStorage.getItem('auth_token')
@@ -38,6 +39,7 @@ async function loadUsername() {
       headers: { Authorization: `Bearer ${token}` },
     })
     username.value = res.data.username
+    userId.value = res.data.id
   } catch (err) {
     console.error(err)
   }
@@ -84,6 +86,7 @@ async function addTrack() {
     await axios.post(`/api/queue/${guildId}/add`, {
       url: newUrl.value,
       requester: username.value || undefined,
+      requesterUId: userId.value || undefined,
     })
     newUrl.value = ''
     await loadData()


### PR DESCRIPTION
## Summary
- allow adding tracks via `/api/queue/{guildId}/add`
- document new player capability

## Testing
- `npm run lint`
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_684f2c641880832cbcbff0c699901484