### PR TITLE
Add invite page with bot link

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -104,6 +104,7 @@ function updateLoggedIn(val: boolean) {
       <div class="flex">
         <RouterLink to="/">Home</RouterLink>
         <RouterLink to="/about">About</RouterLink>
+        <RouterLink to="/invite">Invite</RouterLink>
       </div>
       <div class="flex" v-if="!isLoggedIn">
         <RouterLink to="/login">Login</RouterLink>

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -18,6 +18,11 @@ const router = createRouter({
       component: () => import('../views/AboutView.vue'),
     },
     {
+      path: '/invite',
+      name: 'invite',
+      component: () => import('../views/InviteView.vue'),
+    },
+    {
       path: '/login',
       name: 'login',
       component: () => import('../views/LoginView.vue'),

--- a/src/views/InviteView.vue
+++ b/src/views/InviteView.vue
@@ -1,0 +1,26 @@
+<script setup lang="ts">
+const inviteLink = 'https://discord.com/oauth2/authorize?client_id=1371932098851639357'
+</script>
+
+<template>
+  <main class="invite">
+    <h1>Invite the bot to your server</h1>
+    <a :href="inviteLink" class="invite-link" target="_blank" rel="noopener">Invite Link</a>
+  </main>
+</template>
+
+<style scoped>
+.invite {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  height: 100vh;
+  gap: 1rem;
+}
+
+.invite-link {
+  color: #5865f2;
+  font-size: 1.2em;
+}
+</style>


### PR DESCRIPTION
## Summary
- create `InviteView` with bot invite link
- register `/invite` route
- show Invite in navbar

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68506bb71178832ca2942bb0b95b516c