### PR TITLE
Add invite page with bot link

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -104,6 +104,7 @@ function updateLoggedIn(val: boolean) {
       <div class="flex">
         <RouterLink to="/">Home</RouterLink>
         <RouterLink to="/about">About</RouterLink>
+        <RouterLink to="/invite">Invite</RouterLink>
       </div>
       <div class="flex" v-if="!isLoggedIn">
         <RouterLink to="/login">Login</RouterLink>

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -18,6 +18,11 @@ const router = createRouter({
       component: () => import('../views/AboutView.vue'),
     },
     {
+      path: '/invite',
+      name: 'invite',
+      component: () => import('../views/InviteView.vue'),
+    },
+    {
       path: '/login',
       name: 'login',
       component: () => import('../views/LoginView.vue'),

--- a/src/views/InviteView.vue
+++ b/src/views/InviteView.vue
@@ -1,0 +1,82 @@
+<script setup lang="ts">
+const inviteLink =
+  'https://discord.com/oauth2/authorize?client_id=1371932098851639357'
+</script>
+
+<template>
+  <main class="invite-container">
+    <div class="invite-box">
+      <img
+        src="/Discord-Symbol-Blurple.png"
+        alt="Discord Logo"
+        class="discord-logo"
+      />
+      <h1>Invite Dis Bot</h1>
+      <p>Add the bot to your server and start listening together!</p>
+      <a
+        :href="inviteLink"
+        class="invite-button"
+        target="_blank"
+        rel="noopener"
+      >
+        Invite Bot
+      </a>
+    </div>
+  </main>
+</template>
+
+<style scoped>
+.invite-container {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 100vh;
+}
+
+.invite-box {
+  background: #23272a;
+  padding: 40px;
+  border-radius: 12px;
+  box-shadow: 0 0 15px rgba(0, 0, 0, 0.4);
+  text-align: center;
+  max-width: 400px;
+  width: 90%;
+}
+
+.discord-logo {
+  width: 80px;
+  margin-bottom: 20px;
+  display: block;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+h1 {
+  color: #fff;
+  font-size: 2em;
+  margin-bottom: 10px;
+}
+
+p {
+  color: #b9bbbe;
+  font-size: 1.2em;
+  margin-bottom: 30px;
+}
+
+.invite-button {
+  background-color: #5865f2;
+  color: white;
+  border: none;
+  padding: 12px 20px;
+  font-size: 1em;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: background-color 0.3s ease;
+  text-decoration: none;
+  display: inline-block;
+}
+
+.invite-button:hover {
+  background-color: #4752c4;
+}
+</style>


### PR DESCRIPTION
## Summary
- create `InviteView` with bot invite link
- register `/invite` route
- show Invite in navbar
- style invite page with a centered box, Discord icon and button

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68506bb71178832ca2942bb0b95b516c