### PR TITLE
Improve player controls style

### DIFF
--- a/src/views/PlayerView.vue
+++ b/src/views/PlayerView.vue
@@ -129,7 +129,9 @@ onMounted(() => {
       No track playing
     </div>
 
-    <div class="controls flex flex-wrap gap-2 justify-center">
+    <div
+      class="controls flex flex-wrap justify-center gap-4 bg-gray-800 p-4 rounded-lg shadow-md mx-auto w-fit"
+    >
       <button
         class="px-4 py-2 bg-gray-700 hover:bg-gray-600 rounded text-white"
         @click="pause"


### PR DESCRIPTION
## Summary
- restyle the player controls container so it's centered with a background and padding

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build-only`

------
https://chatgpt.com/codex/tasks/task_e_6850700abbd8832cba309c0bcb970a55